### PR TITLE
chore(security): introduce Takumi Guard composite action for GitHub Actions

### DIFF
--- a/.github/actions/takumi-guard-setup/action.yml
+++ b/.github/actions/takumi-guard-setup/action.yml
@@ -1,0 +1,8 @@
+name: 'Takumi Guard setup'
+description: 'Configure package registries to route through Takumi Guard'
+runs:
+  using: 'composite'
+  steps:
+    - uses: flatt-security/setup-takumi-guard-rubygems@ce18aae2e17e26d6510008ada35a08fff356179a # v1
+      with:
+        bot-id: "BT01KRJ741G9T8KN3Y91SHA5KF1F"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
@@ -21,6 +24,7 @@ jobs:
           - '3.3'
     steps:
     - uses: actions/checkout@v4
+    - uses: ./.github/actions/takumi-guard-setup
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/takumi-guard-setup
 
       - name: Setup Ruby 3.x
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## 背景

npm を中心とした supply chain 攻撃 (Shai-Hulud 類似事象) への予防対応として、Takumi Guard をこの repo の GitHub Actions に導入します。
詳細は社内インシデント Plan を参照してください。

## 変更内容

- `.github/actions/takumi-guard-setup/action.yml` を新規作成 (この repo で使う ecosystem の setup-takumi-guard-* を束ねる composite action)
- 既存の各 workflow の各 job について、`actions/checkout` の直後に `uses: ./.github/actions/takumi-guard-setup` を 1 行追記
- 上記 job の `permissions:` に `id-token: write` と `contents: read` をマージ (既存値は保持。root level の permissions ブロックは触らず、root の全キー + `id-token: write` の union を job level に展開)
- `flatt-security/setup-takumi-guard-*` は third-party action のため 40-char commit SHA で pin

## レビュー観点

- composite action にハードコードされた `bot-id` が、この repo が属する org と一致していること
- CI が green であること (id-token 周りで失敗する場合は permissions マージが効いているか確認)
- Renovate / Dependabot が生成する PR の CI でも新 step が正しく走ること

Plan reference: `plan.sha256:f75721c41ccec727f7e05def986a7e2fed7e94e02d8d29c5ca0299e88c3afd8f / executed by mew-ton@hacomono / 2026-05-14T18:30+09:00`

Closes #9
